### PR TITLE
fix: correct Maven build workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,7 +13,6 @@ on:
     paths-ignore:
       - "docs/**"
       - "*.md"
-      - ".github/**"
   push:
     branches-ignore:
       - "main"
@@ -23,22 +22,40 @@ on:
     paths-ignore:
       - "docs/**"
       - "*.md"
-      - ".github/**"
   workflow_dispatch: {}
 
-permissions:
-  packages: write
-  contents: read
+permissions: {}
+
+concurrency:
+  group: maven-build-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   mvn-snapshot-deploy:
-    uses: netcracker/qubership-workflow-hub/.github/workflows/re-maven-snapshot-deploy.yaml@8c6dbeb901920bae9f40d7d7b646d8d9127e1ce7 # v2.4.0
-    with:
-      java-version: "21"
-      maven-version: "3.9.10"
-      additional-mvn-args: ""
-      target-store: "github-packages"
-    secrets:
-      maven-token: ${{ secrets.GITHUB_TOKEN }}
-      gpg-passphrase: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
-      gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Deploy Maven Snapshot
+        uses: netcracker/qubership-workflow-hub/actions/maven-snapshot-deploy@8c6dbeb901920bae9f40d7d7b646d8d9127e1ce7 # v2.4.0
+        with:
+          java-version: "21"
+          maven-version: "3.9.10"
+          maven-command: ${{ github.event_name == 'pull_request' && 'install' || 'deploy' }}
+          additional-mvn-args: >-
+            ${{
+              github.event_name == 'pull_request' &&
+              '' ||
+              '-DaltDeploymentRepository=github::https://maven.pkg.github.com/Netcracker/qubership-graylog-archiving-plugin'
+            }}
+          target-store: "github"
+          maven-username: ${{ github.actor }}
+          maven-token: ${{ github.token }}
+          gpg-passphrase: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
+          gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary
- replace the missing reusable Maven workflow call with the pinned maven-snapshot-deploy action
- use the documented GitHub Packages target-store value
- run Maven install on pull_request events and keep snapshot deploy for push/manual runs
- move permissions to the job and add workflow concurrency

## Verification
- actionlint .github/workflows/build.yaml
- pre-commit hooks during commit